### PR TITLE
Cortex-M SIP support

### DIFF
--- a/plat/imx/common/imx_sip_handler.c
+++ b/plat/imx/common/imx_sip_handler.c
@@ -146,7 +146,7 @@ int imx_misc_set_temp_handler(uint32_t smc_fid,
 
 #endif /* defined(PLAT_imx8qm) || defined(PLAT_imx8qx) */
 
-#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq)
+#if defined(PLAT_imx8mm) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp) || defined(PLAT_imx8mq)
 int imx_src_handler(uint32_t smc_fid,
 		    u_register_t x1,
 		    u_register_t x2,
@@ -156,6 +156,7 @@ int imx_src_handler(uint32_t smc_fid,
 	uint32_t val;
 
 	switch (x1) {
+#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq)
 	case IMX_SIP_SRC_SET_SECONDARY_BOOT:
 		if (x2 != 0U) {
 			mmio_setbits_32(IMX_SRC_BASE + SRC_GPR10_OFFSET,
@@ -168,6 +169,26 @@ int imx_src_handler(uint32_t smc_fid,
 	case IMX_SIP_SRC_IS_SECONDARY_BOOT:
 		val = mmio_read_32(IMX_SRC_BASE + SRC_GPR10_OFFSET);
 		return !!(val & SRC_GPR10_PERSIST_SECONDARY_BOOT);
+#endif /* defined(PLAT_imx8mm) || defined(PLAT_imx8mq) */
+#if defined(PLAT_imx8mm)
+	case IMX_SIP_SRC_START_M_CORE:
+		val = mmio_read_32(IMX_SRC_BASE + SRC_M4RCR_OFFSET);
+		val &= ~SRC_SW_M4C_NON_SCLR_RST;
+		val |= SRC_ENABLE_M4;
+		mmio_write_32(IMX_SRC_BASE + SRC_M4RCR_OFFSET, val);
+		break;
+	case IMX_SIP_SRC_IS_M_CORE_STARTED:
+		val = mmio_read_32(IMX_SRC_BASE + SRC_M4RCR_OFFSET);
+		return !(val & SRC_SW_M4C_NON_SCLR_RST);
+#endif /* defined(PLAT_imx8mm) */
+#if defined(PLAT_imx8mn) || defined(PLAT_imx8mp)
+	case IMX_SIP_SRC_START_M_CORE:
+		mmio_clrbits_32(IMX_IOMUX_GPR_BASE + IOMUXC_GPR22, GPR_M7_CPUWAIT);
+		break;
+	case IMX_SIP_SRC_IS_M_CORE_STARTED:
+		val = mmio_read_32(IMX_IOMUX_GPR_BASE + IOMUXC_GPR22);
+		return !(val & GPR_M7_CPUWAIT);
+#endif /* defined(PLAT_imx8mn) || defined(PLAT_imx8mp) */
 	default:
 		return SMC_UNK;
 
@@ -175,7 +196,7 @@ int imx_src_handler(uint32_t smc_fid,
 
 	return 0;
 }
-#endif /* defined(PLAT_imx8mm) || defined(PLAT_imx8mq) */
+#endif /* defined(PLAT_imx8mm) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp) || defined(PLAT_imx8mq) */
 
 static uint64_t imx_get_commit_hash(u_register_t x2,
 		    u_register_t x3,

--- a/plat/imx/common/imx_sip_svc.c
+++ b/plat/imx/common/imx_sip_svc.c
@@ -48,7 +48,7 @@ static uintptr_t imx_sip_handler(unsigned int smc_fid,
 	case IMX_SIP_MISC_SET_TEMP:
 		SMC_RET1(handle, imx_misc_set_temp_handler(smc_fid, x1, x2, x3, x4));
 #endif
-#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq)
+#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp)
 	case IMX_SIP_SRC:
 		SMC_RET1(handle, imx_src_handler(smc_fid, x1, x2, x3, handle));
 		break;

--- a/plat/imx/common/include/imx_sip_svc.h
+++ b/plat/imx/common/include/imx_sip_svc.h
@@ -18,6 +18,8 @@
 #define IMX_SIP_BUILDINFO_GET_COMMITHASH	0x00
 
 #define IMX_SIP_SRC			0xC2000005
+#define IMX_SIP_SRC_START_M_CORE	0x00
+#define IMX_SIP_SRC_IS_M_CORE_STARTED	0x01
 #define IMX_SIP_SRC_SET_SECONDARY_BOOT	0x10
 #define IMX_SIP_SRC_IS_SECONDARY_BOOT	0x11
 
@@ -42,7 +44,7 @@ int imx_soc_info_handler(uint32_t smc_fid, u_register_t x1,
 			 u_register_t x2, u_register_t x3);
 #endif
 
-#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq)
+#if defined(PLAT_imx8mm) || defined(PLAT_imx8mq) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp)
 int imx_src_handler(uint32_t smc_fid, u_register_t x1,
 		    u_register_t x2, u_register_t x3, void *handle);
 #endif

--- a/plat/imx/imx8m/imx8mm/include/platform_def.h
+++ b/plat/imx/imx8m/imx8mm/include/platform_def.h
@@ -124,11 +124,15 @@
 
 #define SRC_A53RCR0			U(0x4)
 #define SRC_A53RCR1			U(0x8)
+#define SRC_M4RCR_OFFSET		U(0xC)
 #define SRC_OTG1PHY_SCR			U(0x20)
 #define SRC_OTG2PHY_SCR			U(0x24)
 #define SRC_GPR1_OFFSET			U(0x74)
 #define SRC_GPR10_OFFSET		U(0x98)
 #define SRC_GPR10_PERSIST_SECONDARY_BOOT	BIT(30)
+
+#define SRC_ENABLE_M4			BIT(3)
+#define SRC_SW_M4C_NON_SCLR_RST	BIT(0)
 
 #define SNVS_LPCR			U(0x38)
 #define SNVS_LPCR_SRTC_ENV		BIT(0)

--- a/plat/imx/imx8m/imx8mn/imx8mn_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mn/imx8mn_bl31_setup.c
@@ -211,6 +211,10 @@ void bl31_platform_setup(void)
 	plat_gic_init();
 
 	imx_gpc_init();
+
+	/* Enable and reset M7 */
+	mmio_setbits_32(IMX_SRC_BASE + SRC_M7RCR_OFFSET, SRC_ENABLE_M7);
+	mmio_clrbits_32(IMX_SRC_BASE + SRC_M7RCR_OFFSET, SRC_SW_M7C_NON_SCLR_RST);
 }
 
 entry_point_info_t *bl31_plat_get_next_image_ep_info(unsigned int type)

--- a/plat/imx/imx8m/imx8mn/include/platform_def.h
+++ b/plat/imx/imx8m/imx8mn/include/platform_def.h
@@ -108,8 +108,12 @@
 
 #define SRC_A53RCR0			U(0x4)
 #define SRC_A53RCR1			U(0x8)
+#define SRC_M7RCR_OFFSET		U(0xC)
 #define SRC_OTG1PHY_SCR			U(0x20)
 #define SRC_GPR1_OFFSET			U(0x74)
+
+#define SRC_ENABLE_M7			BIT(3)
+#define SRC_SW_M7C_NON_SCLR_RST	BIT(0)
 
 #define SNVS_LPCR			U(0x38)
 #define SNVS_LPCR_SRTC_ENV		BIT(0)
@@ -119,6 +123,9 @@
 #define IOMUXC_GPR10			U(0x28)
 #define GPR_TZASC_EN			BIT(0)
 #define GPR_TZASC_EN_LOCK		BIT(16)
+
+#define IOMUXC_GPR22			U(0x58)
+#define GPR_M7_CPUWAIT			BIT(0)
 
 #define ANAMIX_MISC_CTL			U(0x124)
 #define DRAM_PLL_CTRL			(IMX_ANAMIX_BASE + 0x50)

--- a/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
@@ -207,6 +207,10 @@ void bl31_platform_setup(void)
 	plat_gic_init();
 
 	imx_gpc_init();
+
+	/* Enable and reset M7 */
+	mmio_setbits_32(IMX_SRC_BASE + SRC_M7RCR_OFFSET, SRC_ENABLE_M7);
+	mmio_clrbits_32(IMX_SRC_BASE + SRC_M7RCR_OFFSET, SRC_SW_M7C_NON_SCLR_RST);
 }
 
 entry_point_info_t *bl31_plat_get_next_image_ep_info(unsigned int type)

--- a/plat/imx/imx8m/imx8mp/include/platform_def.h
+++ b/plat/imx/imx8m/imx8mp/include/platform_def.h
@@ -142,9 +142,13 @@
 
 #define SRC_A53RCR0			U(0x4)
 #define SRC_A53RCR1			U(0x8)
+#define SRC_M7RCR_OFFSET		U(0xC)
 #define SRC_OTG1PHY_SCR			U(0x20)
 #define SRC_OTG2PHY_SCR			U(0x24)
 #define SRC_GPR1_OFFSET			U(0x74)
+
+#define SRC_ENABLE_M7			BIT(3)
+#define SRC_SW_M7C_NON_SCLR_RST	BIT(0)
 
 #define SNVS_LPCR			U(0x38)
 #define SNVS_LPCR_SRTC_ENV		BIT(0)
@@ -154,6 +158,9 @@
 #define IOMUXC_GPR10			U(0x28)
 #define GPR_TZASC_EN			BIT(0)
 #define GPR_TZASC_EN_LOCK		BIT(16)
+
+#define IOMUXC_GPR22			U(0x58)
+#define GPR_M7_CPUWAIT			BIT(0)
 
 #define ANAMIX_MISC_CTL			U(0x124)
 #define DRAM_PLL_CTRL			(IMX_ANAMIX_BASE + 0x50)


### PR DESCRIPTION
This is the initial implementation of SMC SIP handler, which supports the start-up of the Cortem-M cluster in i.MX8M SoC family.

Original implementation has been taken from downstream commit [`5e5c28a3a533 ("plat: imx8m: Add the src handler for m4/m7 core boot support")`](https://source.codeaurora.org/external/imx/imx-atf/commit/?id=5e5c28a3a5336e45ba86a4e2844d9ef44c73d7cd) and adapted to adhere the upstream standard implementation, since it already includes the SMC calls to SRC.

Original commit description:
```
Add the SRC SiP handler for M4/M7 boot support on i.MX8M SoC.
```

This PR supersedes #1  