### PR TITLE
Enable UART1 for DID0 access

### DIFF
--- a/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
@@ -52,6 +52,7 @@ static const struct imx_rdc_cfg rdc[] = {
 
 	/* peripherals domain permission */
 	RDC_PDAPn(RDC_PDAP_UART2, D0R | D0W),
+	RDC_PDAPn(RDC_PDAP_UART1, D0R | D0W),
 
 	/* memory region */
 


### PR DESCRIPTION
_TF-A_ sets the Peripheral Domain Access Permissions (`RDC_PDAPn`), where access to _UART3/4_ are limited to _M7_ and access to _UART2_ is limited to _A53_ on _i.MX8MP_ platform.

Allow read and write access to _UART1_ from Domain 0 (_A53_), as it is used by bootloaders and Linux OS in some designs as a debug UART alternative to NXP EVK setup.