### PR TITLE
[Draft] Setup CSU to set all peripherals to non-secure

### DIFF
--- a/plat/imx/imx8m/imx8m_csu.c
+++ b/plat/imx/imx8m/imx8m_csu.c
@@ -54,3 +54,17 @@ void imx_csu_init(const struct imx_csu_cfg *csu_cfg)
 		csu++;
 	}
 }
+
+void imx_csu_secure_peripherals(void)
+{
+	uint32_t val;
+	uint32_t reg;
+
+	reg = CSU_SA_REG(0x0); // resolves to IMX_CSU_BASE + 0x218
+	val = CSU_SA_ALL_NONSECURE;
+	mmio_write_32(reg, val);
+
+	val = CSU_SA_LOCK_NONSECURE;
+	mmio_write_32(reg, val);
+
+};

--- a/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
@@ -149,6 +149,8 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 
 	imx_csu_init(csu_cfg);
 
+	imx_csu_secure_peripherals();
+
 	if (console_base == 0U) {
 		console_base = imx8m_uart_get_base();
 	}

--- a/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
@@ -136,6 +136,8 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 
 	imx_csu_init(csu_cfg);
 
+	imx_csu_secure_peripherals();
+
 	/* config the ocram memory range for secure access */
 	mmio_write_32(IMX_IOMUX_GPR_BASE + 0x2c, 0x4E1);
 	val = mmio_read_32(IMX_IOMUX_GPR_BASE + 0x2c);

--- a/plat/imx/imx8m/include/imx8m_csu.h
+++ b/plat/imx/imx8m/include/imx8m_csu.h
@@ -35,6 +35,9 @@
 #define CSU_SA_LOCK(x)		((0x1 << (((x) % 16) * 2 + 1)))
 #define CSU_SA_CFG(x, n)	((x) << (((n) % 16) * 2))
 
+#define CSU_SA_ALL_NONSECURE	0x55555554
+#define CSU_SA_LOCK_NONSECURE	0xfffffffc
+
 #define CSU_HPCONTROL_REG(x)		(IMX_CSU_BASE + (((x) / 16) * 4) + 0x358)
 #define CSU_HPCONTROL_LOCK(x)		((0x1 << (((x) % 16) * 2 + 1)))
 #define CSU_HPCONTROL_CFG(x, n)		((x) << (((n) % 16) * 2))
@@ -70,5 +73,7 @@ struct imx_csu_cfg {
 	{CSU_HPCONTROL, .idx = (i), .hpctrl = (val), .lock = (lk), }
 
 void imx_csu_init(const struct imx_csu_cfg *csu_cfg);
+
+void imx_csu_secure_peripherals(void);
 
 #endif /* IMX_CSU_H */


### PR DESCRIPTION
Add a function to set all peripherals to non-secure for i.MX8M and use it for i.MX8MM/MP.