### PR TITLE
fix(imx8m): allow write access to snvs LPSR register to reset SPO

### DIFF
--- a/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
@@ -210,9 +210,7 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 #endif
 #endif
 
-#if !defined(SPD_opteed) && !defined(SPD_trusty)
 	enable_snvs_privileged_access();
-#endif
 
 	bl31_tzc380_setup();
 }

--- a/plat/imx/imx8m/imx8mn/imx8mn_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mn/imx8mn_bl31_setup.c
@@ -192,9 +192,7 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 #endif
 #endif
 
-#if !defined(SPD_opteed) && !defined(SPD_trusty)
 	enable_snvs_privileged_access();
-#endif
 
 	bl31_tzc380_setup();
 }

--- a/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mp/imx8mp_bl31_setup.c
@@ -215,9 +215,7 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 #endif
 #endif
 
-#if !defined(SPD_opteed) && !defined(SPD_trusty)
 	enable_snvs_privileged_access();
-#endif
 
 	bl31_tzc380_setup();
 }


### PR DESCRIPTION
Allow write access to the snvs registers - namely the Low-Power Status Register (LPSR) to be able to reset the interrupt flag BIT(18) = SPO, which is required for the linux-kernel drivers/input/keyboard/snvs_pwrkey to be able/allowed to reset the interrupt flag and continue handling the BTN status (via polling).

The LPSR register used to be 'non privileged' on the imx6, for which the kernel code was probably written, but changed to a priviledged register with the newer imxs; now on a secured ic, the interrupt keeps firing with no means of resetting it, because the access to the priviledged registers is disabled.