### PR TITLE
imx8mp: enable PSCI statistics

### DIFF
--- a/plat/imx/imx8m/imx8mp/platform.mk
+++ b/plat/imx/imx8m/imx8mp/platform.mk
@@ -141,6 +141,12 @@ $(ROTPK_HASH): $(ROT_KEY) | $$(@D)/
 	${OPENSSL_BIN_PATH}/openssl dgst -sha256 -binary > $@ 2>/dev/null
 endif
 
+ENABLE_PSCI_STAT	:=	1
+ENABLE_PMF      	:=	1
+ifeq (${ENABLE_PMF},1)
+BL31_SOURCES		+=	lib/pmf/pmf_smc.c
+endif
+
 ENABLE_PIE		:=	1
 USE_COHERENT_MEM	:=	1
 RESET_TO_BL31		:=	1


### PR DESCRIPTION
Enable PSCI statistics. This feature has a dependency on Performance Measurement Framework (PMF) so enable PMF as well.